### PR TITLE
feat(ui): display JSON content in message panel with arrow indicators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@
 - Description: imperative mood, lowercase start, no period
 - Body: optional, separated by blank line, provides additional context
 - Footer: optional, for metadata like `BREAKING CHANGE:` or issue references
+- Do NOT include AI-generated signatures like:
+  - `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+  - `Co-Authored-By: Claude ... <noreply@anthropic.com>`
+- Same rule applies to pull request descriptions
 
 ## Git workflow
 

--- a/src/components/message_item.rs
+++ b/src/components/message_item.rs
@@ -13,32 +13,89 @@
 // limitations under the License.
 
 use gpui::*;
-use gpui_component::StyledExt;
+use gpui_component::{ActiveTheme as _, StyledExt};
 
 #[derive(IntoElement)]
 pub struct MessageItem {
     title: SharedString,
+    json_content: SharedString,
     is_response: bool,
 }
 
 impl MessageItem {
-    pub fn new(title: impl Into<SharedString>, is_response: bool) -> Self {
-        Self { title: title.into(), is_response }
+    pub fn new(
+        title: impl Into<SharedString>,
+        json_content: impl Into<SharedString>,
+        is_response: bool,
+    ) -> Self {
+        Self { title: title.into(), json_content: json_content.into(), is_response }
     }
 
-    fn get_bg_color(&self) -> Hsla {
+    fn arrow_icon(&self) -> &'static str {
+        if self.is_response {
+            "↑" // Response: coming up from agent
+        } else {
+            "↓" // Request: going down to agent
+        }
+    }
+
+    fn arrow_color(&self) -> Hsla {
         if self.is_response {
             rgb(0xa3be8c).into() // Green for response
         } else {
-            rgb(0xd8dee9).into() // Blue for request
+            rgb(0x5e81ac).into() // Blue for request
         }
     }
 }
 
 impl RenderOnce for MessageItem {
-    fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
-        div().flex().flex_col().bg(self.get_bg_color()).rounded_md().p_3().m_2().child(
-            div().text_sm().font_semibold().text_color(rgb(0x2e3440)).child(self.title.clone()),
-        )
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
+        let arrow = self.arrow_icon();
+        let arrow_color = self.arrow_color();
+
+        div()
+            .flex()
+            .flex_col()
+            .bg(cx.theme().tab_bar)
+            .border_1()
+            .border_color(cx.theme().border)
+            .rounded_md()
+            .px_2()
+            .py_1p5()
+            .mb_1()
+            // Header row: arrow + title
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_1p5()
+                    .child(div().text_sm().font_semibold().text_color(arrow_color).child(arrow))
+                    .child(
+                        div()
+                            .text_sm()
+                            .font_semibold()
+                            .text_color(cx.theme().foreground)
+                            .child(self.title.clone()),
+                    ),
+            )
+            // JSON content area
+            .child(
+                div()
+                    .mt_1p5()
+                    .px_2()
+                    .py_1()
+                    .bg(cx.theme().secondary)
+                    .rounded(px(4.))
+                    .overflow_x_hidden()
+                    .child(
+                        div()
+                            .text_sm()
+                            .font_family("monospace")
+                            .text_color(cx.theme().secondary_foreground)
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .child(self.json_content.clone()),
+                    ),
+            )
     }
 }


### PR DESCRIPTION
Display ACP request and response JSON content in the message panel. Arrow direction indicators (↓ for requests, ↑ for responses) distinguish message types. JSON-RPC formatted content is displayed in monospace font with theme colors. Sample messages included for major ACP operations (initialize, authenticate, session management, filesystem operations, and terminal control).